### PR TITLE
Fix ratelimit metric name

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Metric | Description
 ------ | -----------
 azure_resource_health_availability_up | [Resource health](https://docs.microsoft.com/en-us/azure/service-health/resource-health-overview) availability that relies on signals from different Azure services to assess whether a resource is healthy. This UP metric is 0 if availability status is `Unavailable`, and is 1 otherwise.
 azure_tag_info | Tags of the Azure resource, exposed only if `expose_azure_tag_info` config is set to true
-azure_resource_health_ratelimit_remaining_count | Azure subscription scoped Resource Health requests remaining (based on `X-Ms-Ratelimit-Remaining-Subscription-Resource-Requests` header)
+azure_resource_health_ratelimit_remaining_requests | Azure subscription scoped Resource Health requests remaining (based on `X-Ms-Ratelimit-Remaining-Subscription-Resource-Requests` header)
 
 Example:
 
@@ -112,9 +112,9 @@ azure_resource_health_availability_up{resource_group="my_group",resource_name="m
 # HELP azure_tag_info Tags of the Azure resource
 # TYPE azure_tag_info gauge
 azure_tag_info{resource_group="my_group",resource_name="my_name",resource_type="Microsoft.Storage/storageAccounts",subscription_id="xxx",tag_monitoring="enabled"} 1
-# HELP azure_resource_health_ratelimit_remaining_count Azure subscription scoped Resource Health requests remaining (based on X-Ms-Ratelimit-Remaining-Subscription-Resource-Requests header)
-# TYPE azure_resource_health_ratelimit_remaining_count gauge
-azure_resource_health_ratelimit_remaining_count{subscription_id="xxx"} 98
+# HELP azure_resource_health_ratelimit_remaining_requests Azure subscription scoped Resource Health requests remaining (based on X-Ms-Ratelimit-Remaining-Subscription-Resource-Requests header)
+# TYPE azure_resource_health_ratelimit_remaining_requests gauge
+azure_resource_health_ratelimit_remaining_requests{subscription_id="xxx"} 98
 ```
 
 ## Contributing

--- a/resource_health_collector.go
+++ b/resource_health_collector.go
@@ -110,7 +110,7 @@ func (c *ResourceHealthCollector) CollectRateLimitRemaining(ch chan<- prometheus
 	}
 
 	ch <- prometheus.MustNewConstMetric(
-		prometheus.NewDesc("azure_resource_health_ratelimit_remaining_count", "Azure subscription scoped Resource Health requests remaining (based on X-Ms-Ratelimit-Remaining-Subscription-Resource-Requests header)", nil, labels),
+		prometheus.NewDesc("azure_resource_health_ratelimit_remaining_requests", "Azure subscription scoped Resource Health requests remaining (based on X-Ms-Ratelimit-Remaining-Subscription-Resource-Requests header)", nil, labels),
 		prometheus.GaugeValue,
 		ratelimitRemaining,
 	)

--- a/resource_health_collector_test.go
+++ b/resource_health_collector_test.go
@@ -160,9 +160,9 @@ func TestCollect_Collect_Ok(t *testing.T) {
 	want := `# HELP azure_resource_health_availability_up Resource health availability that relies on signals from different Azure services to assess whether a resource is healthy
 # TYPE azure_resource_health_availability_up gauge
 azure_resource_health_availability_up{resource_group="my_rg",resource_name="my_instance",resource_type="Microsoft.Compute/virtualMachines",subscription_id="my_subscription"} 0
-# HELP azure_resource_health_ratelimit_remaining_count Azure subscription scoped Resource Health requests remaining (based on X-Ms-Ratelimit-Remaining-Subscription-Resource-Requests header)
-# TYPE azure_resource_health_ratelimit_remaining_count gauge
-azure_resource_health_ratelimit_remaining_count{subscription_id="my_subscription"} 99
+# HELP azure_resource_health_ratelimit_remaining_requests Azure subscription scoped Resource Health requests remaining (based on X-Ms-Ratelimit-Remaining-Subscription-Resource-Requests header)
+# TYPE azure_resource_health_ratelimit_remaining_requests gauge
+azure_resource_health_ratelimit_remaining_requests{subscription_id="my_subscription"} 99
 # HELP azure_tag_info Tags of the Azure resource
 # TYPE azure_tag_info gauge
 azure_tag_info{resource_group="my_rg",resource_name="my_instance",resource_type="Microsoft.Compute/virtualMachines",subscription_id="my_subscription"} 1


### PR DESCRIPTION
To align with Prometheus conventions (avoid "_count"), and add precision